### PR TITLE
Use string similarity to compare artist name

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -18,7 +18,8 @@ app.get('/lyrics', async function (req, res) {
         const song = response.hits.find((hit) => {
             if (hit.type === 'song') {
                 const titleSimilarityNumber = stringSimilarity.compareTwoStrings(title, hit.result.title_with_featured.toLowerCase());
-                return titleSimilarityNumber > 0.9 && hit.result.primary_artist.name.toLowerCase() === artist;
+                const artistSimilarityNumber = stringSimilarity.compareTwoStrings(artist, hit.result.primary_artist.name.toLowerCase());
+                return titleSimilarityNumber > 0.9 && artistSimilarityNumber > 0.9;
             }
             return false;
         })


### PR DESCRIPTION
I found out that some artist names can be a little bit different between Spotify and the Genius API response. For example, `Jackie Hill Perry` is found as `Jackie Hill-Perry` in Genius, so the lyrics are not found when doing the equal comparison between the artist data from Spotify and Genius.

The solves follows the same logic from #4, just using the string similarity package to compare the artist data.